### PR TITLE
Add missing <ostream> inclusion

### DIFF
--- a/c++/rearrgroup.cpp
+++ b/c++/rearrgroup.cpp
@@ -35,6 +35,7 @@
 
 #include "rearrgroup.h"
 
+#include <ostream>
 #include <cstdlib>
 
 #include "cansam/exception.h"


### PR DESCRIPTION
Fixes #36.  If you've inherited something you don't understand, you might consider asking the original author or others who do understand C++ for advice…